### PR TITLE
Add blocks as a secondary attachment

### DIFF
--- a/src/plusplus.js
+++ b/src/plusplus.js
@@ -281,29 +281,31 @@ module.exports = function plusPlus(robot) {
       .concat('`how much are <point_type> points worth` - Shows how much <point_type> points are worth\n');
 
     const message = {
-      blocks: [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: 'Need help with qrafty?',
+      attachments: [{
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: 'Need help with qrafty?',
+            },
           },
-        },
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: '_Commands_:',
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: '_Commands_:',
+            },
           },
-        },
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: helpMessage,
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: helpMessage,
+            },
           },
-        },
-      ],
+        ],
+      }],
     };
     msg.send(message);
   }

--- a/test/plusplus.test.js
+++ b/test/plusplus.test.js
@@ -86,15 +86,16 @@ describe('PlusPlus', function plusPlusTest() {
       await (new Promise.delay(30)); // wait for the db call in hubot
 
       const message = room.messages[1][1];
-      expect(message.blocks.length).to.equal(3);
-      expect(message.blocks).to.deep.include({
+      const { blocks } = message.attachments[0];
+      expect(blocks.length).to.equal(3);
+      expect(blocks).to.deep.include({
         type: 'section',
         text: {
           type: 'mrkdwn',
           text: 'Need help with qrafty?',
         },
       });
-      expect(message.blocks).to.deep.include({
+      expect(blocks).to.deep.include({
         type: 'section',
         text: {
           type: 'mrkdwn',


### PR DESCRIPTION
Blocks is not supported by hubot-slack